### PR TITLE
Fix: Importance colors showing as blue

### DIFF
--- a/src/components/features/EconomicCalendar.jsx
+++ b/src/components/features/EconomicCalendar.jsx
@@ -15,6 +15,7 @@ import useTimezone from '../../hooks/useTimezone';
 import typewriterSound from '../../utils/soundUtils';
 import { formatDateInTimezone } from '../../utils/timezoneUtils';
 import { getDateRangeForPeriod, formatRangeForAPI } from '../../utils/dateRangeUtils';
+import { getImportanceConfig } from '../../utils/importanceUtils';
 
 const EconomicCalendar = () => {
   // Component state for filtering
@@ -266,10 +267,7 @@ const EconomicCalendar = () => {
                     <Chip 
                       value={importance.chip} 
                       size="sm" 
-                      color={
-                        importance.value === 'high' ? 'red' :
-                        importance.value === 'medium' ? 'amber' : 'green'
-                      }
+                      color={getImportanceConfig(importance.value)?.color || 'gray'}
                       className="ml-2"
                     />
                   )}
@@ -393,13 +391,7 @@ const EconomicCalendar = () => {
                     <Chip
                       value={event.importance.toUpperCase()}
                       size="sm"
-                      color={
-                        event.importance === 'high'
-                          ? 'red'
-                          : event.importance === 'medium'
-                          ? 'amber'
-                          : 'green'
-                      }
+                      color={getImportanceConfig(event.importance)?.color || 'gray'}
                       className="font-bold"
                     />
                   </td>

--- a/src/components/features/EconomicCalendar.jsx
+++ b/src/components/features/EconomicCalendar.jsx
@@ -398,7 +398,7 @@ const EconomicCalendar = () => {
                           ? 'red'
                           : event.importance === 'medium'
                           ? 'amber'
-                          : 'blue'
+                          : 'green'
                       }
                       className="font-bold"
                     />

--- a/src/utils/importanceUtils.js
+++ b/src/utils/importanceUtils.js
@@ -15,7 +15,7 @@ export const IMPORTANCE_LEVELS = [
   {
     value: 'low',
     label: 'Low Importance',
-    color: 'blue'
+    color: 'green'
   },
   {
     value: 'medium',


### PR DESCRIPTION
Fixes #35

This PR resolves the bug where importance colors were incorrectly showing as blue instead of their intended colors.

## Changes
- Fixed importanceUtils.js: Change low importance from 'blue' to 'green'
- Refactored EconomicCalendar.jsx to use getImportanceConfig() utility
- Ensured consistent color mapping across dropdown and table chips
- Colors now: Low=green, Medium=amber, High=red

## Testing
- All existing tests pass (140/140)
- Build successful
- Manual testing with Playwright confirmed the issue and guided the fix

Generated with [Claude Code](https://claude.ai/code)