### PR TITLE
Fix: Table chip colors showing as black

### DIFF
--- a/src/components/features/EconomicCalendar.jsx
+++ b/src/components/features/EconomicCalendar.jsx
@@ -392,7 +392,8 @@ const EconomicCalendar = () => {
                       value={event.importance.toUpperCase()}
                       size="sm"
                       color={getImportanceConfig(event.importance)?.color || 'gray'}
-                      className="font-bold"
+                      variant="filled"
+                      className="font-bold text-white"
                     />
                   </td>
                   <td className="p-4">


### PR DESCRIPTION
Fixes #35

This PR resolves the regression where table importance chips were displaying as black/dark text instead of their intended colors.

## Changes
- Fixed table chips by adding `variant="filled"` and proper styling
- Ensures Material Tailwind colors are consistently applied in table context
- Colors now work correctly: Low=green, Medium=amber, High=red

## Testing
- All existing tests pass
- Build successful
- Manual testing with Playwright confirmed the fix
- Both dropdown and table chips now display correct colors

Generated with [Claude Code](https://claude.ai/code)