### PR TITLE
fix: correct next event synchronization on page load

### DIFF
--- a/components/features/NextEventTypewriter.jsx
+++ b/components/features/NextEventTypewriter.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import useTheme from '../../hooks/useTheme.jsx';
 import typewriterSound from '../../utils/soundUtils';
-import { formatDateInTimezone, getCurrentTimeInCalendarTimezone } from '../../utils/timezoneUtils';
+import { formatDateInTimezone, getCurrentTimeInCalendarTimezone, parseAsUTC } from '../../utils/timezoneUtils';
 import eventService from '../../services/eventService.js';
 
 const NextEventTypewriter = ({ events, selectedEvent, selectedTimezone, morningReportSummary, onSummaryDisplayComplete }) => {
@@ -35,8 +35,8 @@ const NextEventTypewriter = ({ events, selectedEvent, selectedTimezone, morningR
     // First, try to find upcoming events from the current events list
     if (events && events.length > 0) {
       const upcomingEvents = events
-        .filter(event => new Date(event.date) > nowInCalendarTz)
-        .sort((a, b) => new Date(a.date) - new Date(b.date));
+        .filter(event => parseAsUTC(event.date) > nowInCalendarTz)
+        .sort((a, b) => parseAsUTC(a.date) - parseAsUTC(b.date));
       
       if (upcomingEvents.length > 0) {
         return upcomingEvents[0];
@@ -46,8 +46,8 @@ const NextEventTypewriter = ({ events, selectedEvent, selectedTimezone, morningR
     // If no upcoming events today, try tomorrow's events
     if (tomorrowEvents && tomorrowEvents.length > 0) {
       const tomorrowUpcoming = tomorrowEvents
-        .filter(event => new Date(event.date) > nowInCalendarTz)
-        .sort((a, b) => new Date(a.date) - new Date(b.date));
+        .filter(event => parseAsUTC(event.date) > nowInCalendarTz)
+        .sort((a, b) => parseAsUTC(a.date) - parseAsUTC(b.date));
       
       return tomorrowUpcoming[0] || null;
     }
@@ -184,7 +184,7 @@ const NextEventTypewriter = ({ events, selectedEvent, selectedTimezone, morningR
       if (!events || events.length === 0) return;
       
       const nowInCalendarTz = getCurrentTimeInCalendarTimezone();
-      const upcomingEvents = events.filter(event => new Date(event.date) > nowInCalendarTz);
+      const upcomingEvents = events.filter(event => parseAsUTC(event.date) > nowInCalendarTz);
       
       // If no upcoming events today, fetch tomorrow's events
       if (upcomingEvents.length === 0) {

--- a/utils/timezoneUtils.js
+++ b/utils/timezoneUtils.js
@@ -251,29 +251,11 @@ export const isBrowserTimezone = (timezone) => {
 /**
  * Get the current time in the calendar timezone
  * This is used for determining what events are "next" relative to the calendar's timezone
- * @returns {Date} Current time in calendar timezone as a Date object
+ * @returns {Date} Current UTC time - events are stored in UTC and should be compared directly
  */
 export const getCurrentTimeInCalendarTimezone = () => {
-  const now = new Date();
-  
-  // Convert current UTC time to calendar timezone
-  const calendarTimeString = now.toLocaleString('en-CA', {
-    timeZone: CALENDAR_TIMEZONE,
-    year: 'numeric',
-    month: '2-digit', 
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false
-  });
-  
-  // Parse the string back to Date object
-  const [datePart, timePart] = calendarTimeString.split(', ');
-  const [year, month, day] = datePart.split('-').map(Number);
-  const [hour, minute, second] = timePart.split(':').map(Number);
-  
-  // Create Date object representing current time in calendar timezone
-  // This date will be used for comparison with event dates (which are in UTC)
-  return new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+  // Simply return the current UTC time
+  // Event dates are stored in UTC, so we compare UTC to UTC
+  // The calendar timezone is only used for display purposes
+  return new Date();
 };

--- a/utils/timezoneUtils.js
+++ b/utils/timezoneUtils.js
@@ -138,7 +138,7 @@ export const storeTimezone = (timezone) => {
  * @param {string} dateString - The date string to parse
  * @returns {Date} Date object in UTC
  */
-const parseAsUTC = (dateString) => {
+export const parseAsUTC = (dateString) => {
   // If the date string doesn't end with 'Z' and doesn't have timezone info,
   // append 'Z' to ensure it's parsed as UTC
   if (typeof dateString === 'string' && 


### PR DESCRIPTION
Fixes #56

This PR fixes the bug where the "Next Event" terminal was not correctly synchronized on page load.

## Problem
The `getCurrentTimeInCalendarTimezone()` function was using complex timezone string parsing that created offset errors, causing past events to appear as "next" events.

## Solution
Simplified the function to return current UTC time directly, since event dates are stored in UTC and should be compared UTC vs UTC.

## Testing
- ✅ Build passes successfully
- ✅ Verified with simulated bug scenario
- ✅ Past events correctly identified as past
- ✅ Future events correctly identified as upcoming

Generated with [Claude Code](https://claude.ai/code)